### PR TITLE
fix typo in the parameter of gamma distribution

### DIFF
--- a/R/kscheck.R
+++ b/R/kscheck.R
@@ -39,7 +39,7 @@ beta=rgamma(1,gamma+10*alpha)/(delta+sum(lambda))
 
 for (t in 2:T){
   lambda=rbind(lambda,rgamma(10,data+alpha)/(time+beta[t-1]))
-  beta=c(beta,rgamma(1,gamma+10*alpha)/(delta+sum(lambda[t])))
+  beta=c(beta,rgamma(1,gamma+10*alpha)/(delta+sum(lambda[t,])))
   }
 
 beta=beta[seq(1,T,by=M)]


### PR DESCRIPTION
the summation should be performed on the row `t`, instead of the whole matrix.